### PR TITLE
Fix RegEx to properly handle one-line codeblocks

### DIFF
--- a/src/listeners/messageInvalid.js
+++ b/src/listeners/messageInvalid.js
@@ -61,7 +61,7 @@ class MessageInvalidListener extends Listener {
 
         const regex = /^\s*(`{1,3})(.+?)[ \n]([^]+)\1\s*$/;
         const match = message.content.slice(prefix.length).match(regex);
-        if (!match) {
+        if (!match) { 
             return null;
         }
 

--- a/src/listeners/messageInvalid.js
+++ b/src/listeners/messageInvalid.js
@@ -61,7 +61,7 @@ class MessageInvalidListener extends Listener {
 
         const regex = /^\s*(`{1,3})(.+?)[ \n]([^]+)\1\s*$/;
         const match = message.content.slice(prefix.length).match(regex);
-        if (!match) { 
+        if (!match) {
             return null;
         }
 

--- a/src/listeners/messageInvalid.js
+++ b/src/listeners/messageInvalid.js
@@ -59,7 +59,7 @@ class MessageInvalidListener extends Listener {
             return null;
         }
 
-        const regex = /^\s*(`{1,3})(.+?)( |\n)([^]+)\1\s*$/;
+        const regex = /^\s*(`{1,3})(.+?)[ \n]([^]+)\1\s*$/;
         const match = message.content.slice(prefix.length).match(regex);
         if (!match) {
             return null;

--- a/src/listeners/messageInvalid.js
+++ b/src/listeners/messageInvalid.js
@@ -59,7 +59,7 @@ class MessageInvalidListener extends Listener {
             return null;
         }
 
-        const regex = /^\s*(`{1,3})(.+?)\n([^]+)\1\s*$/;
+        const regex = /^\s*(`{1,3})(.+?)( |\n)([^]+)\1\s*$/;
         const match = message.content.slice(prefix.length).match(regex);
         if (!match) {
             return null;


### PR DESCRIPTION
Update regex to properly catch codeblocks without newline after lang (obviously can occur mostly in inline codeblocks)
Performed few checks to see if lang is still properly matched into 2nd capture group, and code is still in 3rd group.